### PR TITLE
fix: enable SharedArrayBuffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
+  <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
   <title>Voice‑Pause‑Video</title>
   <link rel="stylesheet" href="./style.css" />
   <!-- ffmpeg.wasm (loaded from CDN at runtime) -->
   <!-- Load the FFmpeg UMD build (v0.10.0).  This version does not split the library into multiple chunks, avoiding
        cross‑origin worker errors that occurred with later versions.  It automatically fetches the matching
        @ffmpeg/core files from a CDN. -->
-  <script src="https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.10.0/dist/ffmpeg.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.10.0/dist/ffmpeg.min.js" crossorigin="anonymous"></script>
 </head>
 <body>
   <header>

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,9 @@
 [dev]
   command = "npm run serve"
   port = 8080
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cross-Origin-Opener-Policy = "same-origin"
+    Cross-Origin-Embedder-Policy = "require-corp"

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,14 @@
 {
   "version": 2,
   "builds": [{"src": "index.html", "use": "@vercel/static"}],
-  "routes": [{"src": "/(.*)", "dest": "/index.html"}]
+  "routes": [{"src": "/(.*)", "dest": "/index.html"}],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {"key": "Cross-Origin-Opener-Policy", "value": "same-origin"},
+        {"key": "Cross-Origin-Embedder-Policy", "value": "require-corp"}
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add COOP/COEP headers and meta tags so browsers expose `SharedArrayBuffer`
- mark ffmpeg CDN script as cross-origin

## Testing
- `node --loader ts-node/esm tests/pauseResume.test.ts`
- `npm run build` *(fails: Cannot find name 'process')*

------
https://chatgpt.com/codex/tasks/task_b_68964943fe3c8322998dc0164cbbffca