### PR TITLE
feat: display version number on site

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
   </main>
 
   <footer>
-    <small>© 2025</small>
+    <small>© 2025 <span id="version"></span></small>
   </footer>
 
   <!-- Load the compiled JavaScript instead of TypeScript to ensure browsers can execute it -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-pause-video",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,12 @@ const redoBtn = document.getElementById('redoBtn');
 const normalizeChk = document.getElementById('normalizeChk');
 const denoiseChk = document.getElementById('denoiseChk');
 const autosaveChk = document.getElementById('autosaveChk');
+const versionEl = document.getElementById('version');
+
+fetch('./package.json')
+    .then(r => r.json())
+    .then(pkg => { versionEl.textContent = `v${pkg.version}`; })
+    .catch(() => {});
 
 // Additional elements and state for live duration display and waveform during recording.
 // The durationEl element shows the running length of the narration while recording.  The

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,12 @@ const redoBtn = document.getElementById('redoBtn') as HTMLButtonElement;
 const normalizeChk = document.getElementById('normalizeChk') as HTMLInputElement;
 const denoiseChk = document.getElementById('denoiseChk') as HTMLInputElement;
 const autosaveChk = document.getElementById('autosaveChk') as HTMLInputElement;
+const versionEl = document.getElementById('version') as HTMLSpanElement;
+
+fetch('./package.json')
+  .then(r => r.json())
+  .then(pkg => { versionEl.textContent = `v${pkg.version}`; })
+  .catch(() => {});
 
 const waveform = new Waveform(waveCanvas);
 const audioChunks: Blob[] = [];


### PR DESCRIPTION
## Summary
- show package version in site footer
- fetch version from package.json so it auto-updates
- bump package version to 1.0.1

## Testing
- `node --loader ts-node/esm tests/pauseResume.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68964b37c1b88322a2020d64453f5742