### PR TITLE
fix: ensure version number shows on site

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,9 +73,9 @@
     </section>
   </main>
 
-  <footer>
-    <small>© 2025</small>
-  </footer>
+    <footer>
+      <small>© 2025 <span id="version">v1.0.2</span></small>
+    </footer>
 
   <!-- Load the compiled JavaScript instead of TypeScript to ensure browsers can execute it -->
   <script type="module" src="./src/main.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-pause-video",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@
 
 import { Waveform } from './waveform.js';
 import { Exporter } from './exporter.js';
+import pkg from '../package.json' assert { type: 'json' };
 
 // DOM references
 const videoEl = document.getElementById('video');
@@ -23,6 +24,8 @@ const redoBtn = document.getElementById('redoBtn');
 const normalizeChk = document.getElementById('normalizeChk');
 const denoiseChk = document.getElementById('denoiseChk');
 const autosaveChk = document.getElementById('autosaveChk');
+const versionEl = document.getElementById('version');
+versionEl.textContent = `v${pkg.version}`;
 
 // Additional elements and state for live duration display and waveform during recording.
 // The durationEl element shows the running length of the narration while recording.  The

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Waveform } from './waveform';
 import { Exporter, PauseRange } from './exporter';
+import pkg from '../package.json' assert { type: 'json' };
 
 // App State
 type HistoryItem = { type: 'trim'; from: { start: number; end: number }; to: { start: number; end: number } };
@@ -22,6 +23,8 @@ const redoBtn = document.getElementById('redoBtn') as HTMLButtonElement;
 const normalizeChk = document.getElementById('normalizeChk') as HTMLInputElement;
 const denoiseChk = document.getElementById('denoiseChk') as HTMLInputElement;
 const autosaveChk = document.getElementById('autosaveChk') as HTMLInputElement;
+const versionEl = document.getElementById('version') as HTMLSpanElement;
+versionEl.textContent = `v${pkg.version}`;
 
 const waveform = new Waveform(waveCanvas);
 const audioChunks: Blob[] = [];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
     "strictPropertyInitialization": false,


### PR DESCRIPTION
## Summary
- render package version in footer with a default value
- import package.json at build time and drop runtime fetch
- adjust tsconfig for JSON imports and bump version to 1.0.2

## Testing
- `node --loader ts-node/esm tests/pauseResume.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68964b37c1b88322a2020d64453f5742