### PR TITLE
fix SharedArrayBuffer and remove JSON import

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ npm i
 ```bash
 npm run build
 ```
-3. הרצה מקומית (שרת סטטי):
+3. הרצה מקומית (שרת סטטי עם כותרות COOP/COEP):
 ```bash
 npm run serve
 ```
 בדפדפן גלוש ל־http://localhost:8080
+
+> שים/י לב: השרת המקומי מוסיף כותרות `Cross-Origin-Opener-Policy` ו‑`Cross-Origin-Embedder-Policy` הנדרשות להפעלת `SharedArrayBuffer` בדפדפן.
 
 > שים/י לב: בזמן ריצה נטענת ספריית ffmpeg.wasm מה־CDN (unpkg). אין שרת צד-אחורי.
 
@@ -28,4 +30,5 @@ npm run serve
 ```bash
 npm run test
 ```
+
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc -p .",
     "watch": "tsc -w -p .",
-    "serve": "npx http-server -c-1 .",
+    "serve": "node server.mjs",
     "test": "ts-node tests/pauseResume.test.ts"
   },
   "devDependencies": {

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,38 @@
+import http from 'http';
+import { readFile } from 'fs/promises';
+import { extname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const port = process.env.PORT || 8080;
+
+const mime = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.mjs': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.wasm': 'application/wasm',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg'
+};
+
+const server = http.createServer(async (req, res) => {
+  try {
+    let p = req.url;
+    if (!p || p === '/') p = '/index.html';
+    const filePath = join(__dirname, p);
+    const data = await readFile(filePath);
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+    res.setHeader('Content-Type', mime[extname(filePath)] || 'application/octet-stream');
+    res.end(data);
+  } catch {
+    res.statusCode = 404;
+    res.end('Not found');
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Serving on http://localhost:${port}`);
+});

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@
 
 import { Waveform } from './waveform.js';
 import { Exporter } from './exporter.js';
-import pkg from '../package.json' assert { type: 'json' };
 
 // DOM references
 const videoEl = document.getElementById('video');
@@ -25,7 +24,6 @@ const normalizeChk = document.getElementById('normalizeChk');
 const denoiseChk = document.getElementById('denoiseChk');
 const autosaveChk = document.getElementById('autosaveChk');
 const versionEl = document.getElementById('version');
-versionEl.textContent = `v${pkg.version}`;
 
 
 fetch('./package.json')


### PR DESCRIPTION
## Summary
- Remove unsupported JSON import assertion to eliminate syntax error
- Add simple Node dev server with COOP/COEP headers so SharedArrayBuffer works
- Document new server in README and package.json

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for tests/pauseResume.test.ts)*

------
https://chatgpt.com/codex/tasks/task_b_6896513834508322b63d8bc495d82f71